### PR TITLE
fix: sort references from lsp by line

### DIFF
--- a/lua/refjump/jump.lua
+++ b/lua/refjump/jump.lua
@@ -134,6 +134,10 @@ function M.reference_jump_from(current_position, opts, count, references, with_r
       return
     end
 
+    table.sort(refs, function(a, b)
+      return a.range.start.line < b.range.start.line
+    end)
+
     jump_to_next_reference_and_highlight(refs, opts.forward, count, current_position)
 
     if with_references then


### PR DESCRIPTION
When using the Dart lsp and querying the references, the declaration line is the last item in the references list and thus using the `[r` motion always goes to the declaration line. By ensuring the list is actually sorted by line, the issue is fixed.