### PR TITLE
revise keymap descriptions to use terms next/previous

### DIFF
--- a/lua/refjump/keymaps.lua
+++ b/lua/refjump/keymaps.lua
@@ -27,8 +27,8 @@ function M.create_keymaps(opts)
       and repeatable_jump_map
       or jump_map
 
-  vim.keymap.set(nxo, opts.keymaps.next, jump({ forward = true }), { desc = 'Reference jump forward' })
-  vim.keymap.set(nxo, opts.keymaps.prev, jump({ forward = false }), { desc = 'Reference jump backward' })
+  vim.keymap.set(nxo, opts.keymaps.next, jump({ forward = true }), { desc = 'Next reference' })
+  vim.keymap.set(nxo, opts.keymaps.prev, jump({ forward = false }), { desc = 'Previous reference' })
 end
 
 return M


### PR DESCRIPTION
Seeing these in the context of some other keymaps I have set up, I notice that the common phrasing is `Next <foo>` and `Previous <foo>`. To be clear, those are not my own descriptions, but from plugins or maybe even Neovim(?).

![Screenshot from 2024-11-06 at 15_30_26 220095301](https://github.com/user-attachments/assets/8331fb2c-5601-4fdc-81c8-bfd6e09ac343)
