### PR TITLE
feat: set keymap only for buffers with lsp that support it

### DIFF
--- a/doc/refjump.txt
+++ b/doc/refjump.txt
@@ -1,4 +1,4 @@
-*refjump.txt*          For NVIM v0.8.0          Last change: 2024 September 04
+*refjump.txt*           For NVIM v0.8.0           Last change: 2025 January 27
 
 ==============================================================================
 Table of Contents                                  *refjump-table-of-contents*

--- a/lua/refjump/init.lua
+++ b/lua/refjump/init.lua
@@ -45,7 +45,7 @@ function M.setup(opts)
   options = vim.tbl_deep_extend('force', options, opts or {})
 
   if options.keymaps.enable then
-    require('refjump.keymaps').create_keymaps(options)
+    require('refjump.keymaps').create_keymaps_autocmd(options)
   end
 
   if options.highlights.enable then

--- a/lua/refjump/jump.lua
+++ b/lua/refjump/jump.lua
@@ -156,16 +156,6 @@ function M.reference_jump(opts, references, with_references)
     method = 'textDocument/documentHighlight',
   })
 
-  if #compatible_lsp_clients <= 0 then
-    if require('refjump').get_options().verbose then
-      local message = 'refjump.nvim: no LSP client with ' ..
-          '`textDocument/documentHighlight` support found'
-      require('refjump.utils').notify(message, vim.log.levels.WARN)
-    end
-
-    return
-  end
-
   local current_position = vim.api.nvim_win_get_cursor(0)
   local count = vim.v.count1
   M.reference_jump_from(current_position, opts, count, references, with_references)


### PR DESCRIPTION
This pr uses the `LspAttach` event to register the ref jump keymaps only for buffers that have a client attached that supports the required `textDocument/documentHighlight` method.

I encountered this issue when using the ltex lsp for grammatical checks in latex, which conflicted with the keymaps from vimtex.